### PR TITLE
fix(dgclaw.sh): detect provider memo in entries field (acp-cli v2 format)

### DIFF
--- a/scripts/dgclaw.sh
+++ b/scripts/dgclaw.sh
@@ -79,7 +79,7 @@ fund_acp_job() {
     local trigger_found
     trigger_found=$(echo "$status_response" | jq --arg t "$trigger" '
       (if type == "array" then .[0] else . end)
-      | .memoHistory // []
+      | (.memoHistory // .entries // [])
       | [.. | strings | select(contains($t))]
       | length > 0' 2>/dev/null || echo "false")
 


### PR DESCRIPTION
## Issue

`dgclaw.sh join` polls 40 attempts then times out, even though the provider already posted the trigger memo `"Ready to register agent on leaderboard"` in the job history.

Repro from a fresh setup following the README Quick Start:

```
Waiting for provider memo (phase: budget_set, attempt 40/40)...
Error: Timed out waiting for trigger memo on job <jobId> after 40 attempts
```

Looking at the actual job state with `acp job history --chain-id 8453 --job-id <jobId> --json`:

```json
{
  "jobId": "<jobId>",
  "status": "budget_set",
  "entryCount": 2,
  "entries": [
    { "kind": "message", "from": "<my-agent>", "content": "{...}" },
    {
      "kind": "message",
      "from": "0xd478a8B40372db16cA8045F28C6FE07228F3781A",
      "content": "Ready to register agent on leaderboard"
    }
  ]
}
```

The memo is right there in `entries[1].content`, the script just doesn't see it.

## Root cause

In `fund_acp_job` (line 82), trigger detection only looks under `.memoHistory`:

```bash
trigger_found=$(echo "$status_response" | jq --arg t "$trigger" '
  ...
  | .memoHistory // []
  | [.. | strings | select(contains($t))]
  | length > 0' ...)
```

The current `acp job history --json` (acp-cli `main`) returns the memo array under `.entries`, not `.memoHistory`, so `.memoHistory // []` falls through to `[]`, the trigger string is never found, and polling runs to timeout.

## Fix

One-line jq change. Try `.entries` as a fallback while keeping the original `.memoHistory` first for backward compat:

```diff
-      | .memoHistory // []
+      | (.memoHistory // .entries // [])
```

The recursive descent `[.. | strings | select(contains($t))]` is structure-agnostic, so nothing else needs touching.

## After the patch

```
$ ./scripts/dgclaw.sh join
Using agent: <name> (<address>)
Checking agent tokenization...
Agent tokenized: <token>
Generating RSA key pair...
Creating join_leaderboard ACP job...
ACP job created: <jobId>
Funding job...
  Provider memo posted ("Ready to register agent on leaderboard") - funding...
  Funded successfully
Waiting for registration...
Registration completed!
{
  "agentAddress": "...",
  "tokenAddress": "...",
  "encryptedApiKey": "..."
}

Registration complete! API key saved to .env
```

## Notes

The other `.memoHistory` references at lines 61-62 and 128-129 (phase computation) already fall back to `.status // .phase // "PENDING"` when `.memoHistory` is missing, so they handle the new format correctly without any change. Only the trigger detection in `fund_acp_job` was strict about the field name.

The fix is purely additive: when `.memoHistory` is present, the expression returns the same value as before. Only when it's absent does `.entries` take over. So no behavior change for any older `acp-cli` version that may still return `.memoHistory`.

## Setup tested

- Fresh V2 agent (self-hosted, non-custodial), token launched via `app.virtuals.io` web UI
- `acp-cli`: latest `main` (clone fresh), Node.js 20.20.2
- `dgclaw-skill`: commit `3839ee1` (current HEAD of `main`)
- Agent wallet funded with USDC + ETH on Base
- Linux Ubuntu 24.04
